### PR TITLE
Update Ruby on Rails CI workflow to remove path filters

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -8,14 +8,8 @@ name: "Ruby on Rails CI"
 on:
   push:
     branches: [ "main" ]
-    paths:
-      - 'backend/**'
-      - '.github/workflows/rubyonrails.yml'
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'backend/**'
-      - '.github/workflows/rubyonrails.yml'
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removed path filters for push and pull_request events. This allows this to show up as a global status check